### PR TITLE
Auto add local file name if cos path is dir

### DIFF
--- a/util/path.go
+++ b/util/path.go
@@ -25,12 +25,7 @@ func ParsePath(url string) (bucketName string, path string) {
 			return res[0], res[1]
 		}
 	} else {
-		if url[0] == '~' {
-			home, _ := homedir.Dir()
-			path = home + url[1:]
-		} else {
-			path = url
-		}
+		path, _ = homedir.Expand(url)
 		return "", path
 	}
 }

--- a/util/upload.go
+++ b/util/upload.go
@@ -72,6 +72,13 @@ func SingleUpload(c *cos.Client, localPath, bucketName, cosPath string, op *Uplo
 		fileNames := strings.Split(localPath, "/")
 		fileName := fileNames[len(fileNames)-1]
 		cosPath = cosPath + fileName
+	} else {
+		// ~/example/123.txt => cos://bucket/path/
+		// Add 123.txt to cos path
+		if strings.HasSuffix(cosPath, "/") {
+			_, fileName := filepath.Split(localPath)
+			cosPath = filepath.Join(cosPath, fileName)
+		}
 	}
 	// 2. 123.txt => cos://bucket/path/
 	if !filepath.IsAbs(localPath) {


### PR DESCRIPTION
Currently if upload single file to cos path, the filename is required at the end of cos path. If the cos path is a dir (end with /), the upload will be success but the object name will be empty.
So I add some simple code to auto add origin filename to the end of cos path to avoid wasting time and net flow.
Also Fix #11 