### PR TITLE
fix: 移除 secretID/secretKey 的存在判断, 修复匿名访问能力

### DIFF
--- a/util/client.go
+++ b/util/client.go
@@ -1,10 +1,10 @@
 package util
 
 import (
-	"fmt"
-	"github.com/tencentyun/cos-go-sdk-v5"
 	"net/http"
 	"time"
+
+	"github.com/tencentyun/cos-go-sdk-v5"
 )
 
 var secretID, secretKey, secretToken string
@@ -37,14 +37,6 @@ func NewClient(config *Config, param *Param, bucketName string, options ...*File
 	}
 	if param.SessionToken != "" {
 		secretToken = param.SessionToken
-	}
-
-	if secretID == "" {
-		return client, fmt.Errorf("secretID is missing ")
-	}
-
-	if secretKey == "" {
-		return client, fmt.Errorf("secretKey is missing")
 	}
 
 	if bucketName == "" { // 不指定 bucket，则创建用于发送 Service 请求的客户端


### PR DESCRIPTION
1.0.4 的版本在 NewClient 方法中必须要求存在 SecretId / SecretKey，这使得原本的匿名上传下载公开桶（或授权ip白名单写入权限的桶）的功能失效，这个 PR 将这两个存在判断移除以恢复匿名访问能力。